### PR TITLE
feat: 비밀번호 검증 추가

### DIFF
--- a/backend/src/main/java/com/chpark/chcalendar/entity/UserEntity.java
+++ b/backend/src/main/java/com/chpark/chcalendar/entity/UserEntity.java
@@ -1,6 +1,7 @@
 package com.chpark.chcalendar.entity;
 
 import com.chpark.chcalendar.dto.UserDto;
+import com.chpark.chcalendar.exception.PasswordException;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -36,8 +37,29 @@ public class UserEntity {
                 .build();
     }
 
-    public boolean checkPassword(String plainPassword, PasswordEncoder passwordEncoder) {
+    public boolean checkPasswordsMatch(String plainPassword, PasswordEncoder passwordEncoder) {
         return passwordEncoder.matches(plainPassword, this.password);
+    }
+
+    public static void validatePassword(String plainPassword) {
+        int passwordMin = 8;
+        int passwordMax = 20;
+
+        if (plainPassword.length() < passwordMin || plainPassword.length() > passwordMax) {
+            throw new PasswordException(String.format("Password must be between %d ~ %d characters long.", passwordMin, passwordMax));
+        }
+
+        if (!plainPassword.matches(".*[0-9].*")) {
+            throw new PasswordException("Password must contain at least one digit.");
+        }
+
+        if (!(plainPassword.matches(".*[a-z].*") || plainPassword.matches(".*[A-Z].*"))) {
+            throw new PasswordException("Password must contain at least one uppercase or lowercase letter.");
+        }
+
+        if (!plainPassword.matches(".*[!\"#$%&'()*+,-./:;<=>?@\\[\\]^_`{|}~].*")) {
+            throw new PasswordException("Password must contain at least one special character.");
+        }
     }
 
     public void changePassword(String plainPassword, PasswordEncoder passwordEncoder) {

--- a/backend/src/main/java/com/chpark/chcalendar/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/chpark/chcalendar/exception/GlobalExceptionHandler.java
@@ -55,4 +55,12 @@ public class GlobalExceptionHandler {
                 HttpStatus.BAD_REQUEST
         );
     }
+
+    @ExceptionHandler(PasswordException.class)
+    public ResponseEntity<MessageResponseDto> handleGroupAuthority(PasswordException ex) {
+        return new ResponseEntity<>(
+                createCustomErrorResponse(ex, HttpStatus.BAD_REQUEST.value()),
+                HttpStatus.BAD_REQUEST
+        );
+    }
 }

--- a/backend/src/main/java/com/chpark/chcalendar/exception/PasswordException.java
+++ b/backend/src/main/java/com/chpark/chcalendar/exception/PasswordException.java
@@ -1,0 +1,7 @@
+package com.chpark.chcalendar.exception;
+
+public class PasswordException extends RuntimeException{
+    public PasswordException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/chpark/chcalendar/security/SecurityConfig.java
+++ b/backend/src/main/java/com/chpark/chcalendar/security/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
                 .cors(cors -> cors
                     .configurationSource(request -> {
                         CorsConfiguration config = new CorsConfiguration();
-                        config.setAllowedOrigins(Arrays.asList("http://localhost:8080", "https://localhost:3000"));
+                        config.setAllowedOrigins(Arrays.asList("https://localhost:3000"));
                         config.setAllowCredentials(true);
                         config.setAllowedMethods(Arrays.asList("GET", "POST", "PATCH", "PUT", "DELETE", "OPTION"));
                         config.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type"));

--- a/backend/src/test/java/com/chpark/chcalendar/service/UserServiceIntegrationTest.java
+++ b/backend/src/test/java/com/chpark/chcalendar/service/UserServiceIntegrationTest.java
@@ -59,7 +59,7 @@ public class UserServiceIntegrationTest {
         entityManager.clear();
 
         //then
-        assertThat(savedUser.checkPassword(password.getNewPassword(), passwordEncoder)).isTrue();
+        assertThat(savedUser.checkPasswordsMatch(password.getNewPassword(), passwordEncoder)).isTrue();
     }
 
     @Test

--- a/backend/src/test/java/com/chpark/chcalendar/utility/ScheduleUtilityTest.java
+++ b/backend/src/test/java/com/chpark/chcalendar/utility/ScheduleUtilityTest.java
@@ -114,8 +114,8 @@ class ScheduleUtilityTest {
         );
         UserEntity userEntity = UserEntity.createWithEncodedPassword(userRequest, passwordEncoder);
 
-        assertThat(userEntity.checkPassword(rawPassword, passwordEncoder)).isTrue();
-        assertThat(userEntity.checkPassword("password123!@3", passwordEncoder)).isFalse();
+        assertThat(userEntity.checkPasswordsMatch(rawPassword, passwordEncoder)).isTrue();
+        assertThat(userEntity.checkPasswordsMatch("password123!@3", passwordEncoder)).isFalse();
     }
 
 }

--- a/frontend/src/components/pages/ProfilePage.jsx
+++ b/frontend/src/components/pages/ProfilePage.jsx
@@ -146,6 +146,11 @@ const ProfilePage = () => {
               autoComplete="off"
             />
           </div>
+          <div className={styles.passwordText}>
+            <small>
+              Use 8-20 characters with letters, numbers and symbols.<br/>
+            </small>
+          </div>
           <Button
             type="button"
             variant="green"

--- a/frontend/src/components/pages/RegisterPage.jsx
+++ b/frontend/src/components/pages/RegisterPage.jsx
@@ -43,9 +43,9 @@ const RegisterPage = () => {
       })
       .catch((error) => {
         if (error.response) {
-          alert("Error: " + error.response.data);
+          alert(error.response.data);
         } else {
-          alert("Error: " + error.message);
+          alert(error.message);
         }
       });
   };
@@ -70,9 +70,9 @@ const RegisterPage = () => {
       navigate("/auth/login");
     } catch (error) {
       if (error.response) {
-        alert("Error: " + error.response.data.message);
+        alert(error.response.data.message);
       } else {
-        alert("Error: " + error.message);
+        alert(error.message);
       }
     }
   };
@@ -134,9 +134,14 @@ const RegisterPage = () => {
             required
           />
         </div>
-        {!isPasswordMatch && (
-          <small className={styles.passwordError}>Passwords do not match</small>
-        )}
+        <div className={styles.passwordText}>
+          <small>
+            Use 8-20 characters with letters, numbers and symbols.<br/>
+          </small>
+          {!isPasswordMatch && (
+            <small className={styles.passwordError}>Passwords do not match</small>
+          )}
+        </div>
         <div className={styles.infoRow}>
           <label htmlFor="nickname">Nickname:</label>
           <input

--- a/frontend/src/styles/Profile.module.css
+++ b/frontend/src/styles/Profile.module.css
@@ -62,3 +62,8 @@
   margin-top: -10px;
   margin-bottom: 15px;
 }
+
+.passwordText {
+  margin-top: -10px;
+  margin-bottom: 20px;
+}

--- a/frontend/src/styles/Register.module.css
+++ b/frontend/src/styles/Register.module.css
@@ -42,6 +42,11 @@
   gap: 10px;
 }
 
+.passwordText {
+  margin-top: -10px;
+  margin-bottom: 10px;
+}
+
 .passwordError {
   color: red;
   margin-top: -10px;


### PR DESCRIPTION
비밀번호에 대한 검증이 부족해서 추가하게 되었습니다. 8~20 문자, 숫자, 특수문자가 들어가도록 입력해야합니다.

## #️⃣연관된 이슈
>  #28

## 📝작업 내용
- 비밀번호 검증을 8~20자리의 문자, 숫자, 특수문자가 구성되게 추가
- 회원가입, 비밀번호 변경 페이지에서 해당 규칙에 대한 안내 추가

