### PR TITLE
fix: DOM에 대한 경고가 뜨지 않도록 수정

### DIFF
--- a/frontend/src/components/pages/RegisterPage.jsx
+++ b/frontend/src/components/pages/RegisterPage.jsx
@@ -115,6 +115,7 @@ const RegisterPage = () => {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="Enter your password"
+            autoComplete="new-password"
             required
           />
         </div>
@@ -126,6 +127,7 @@ const RegisterPage = () => {
             value={confirmPassword}
             onChange={(e) => setConfirmPassword(e.target.value)}
             placeholder="Confirm your password"
+            autoComplete="new-password"
             required
           />
         </div>


### PR DESCRIPTION
[DOM] Input elements should have autocomplete attributes가 뜨지 않도록
