### PR TITLE
fix: 그룹 캘린더 관련 버그 수정

### DIFF
--- a/backend/src/main/java/com/chpark/chcalendar/repository/schedule/ScheduleRepository.java
+++ b/backend/src/main/java/com/chpark/chcalendar/repository/schedule/ScheduleRepository.java
@@ -23,16 +23,15 @@ public interface ScheduleRepository extends JpaRepository<ScheduleEntity, Long> 
     List<ScheduleEntity> findSchedulesByCalendarId(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end, @Param("calendarId") Long calendarId);
 
     @Query("""
-    SELECT DISTINCT s
+        SELECT DISTINCT s
           FROM ScheduleEntity s
           LEFT JOIN ScheduleGroupEntity sg
                  ON s.id = sg.scheduleId
-         WHERE (s.userId = :userId OR sg.userId = :userId)
+         WHERE (sg IS NULL OR s.userId = :userId OR sg.userId = :userId)
            AND s.calendarId IN :calendarIds
            AND s.startAt <= :end
            AND s.endAt >= :start
-           AND (s.startAt > :cursorStartAt
-                OR (s.startAt = :cursorStartAt AND s.id > :cursorId))
+           AND (s.startAt > :cursorStartAt OR (s.startAt = :cursorStartAt AND s.id > :cursorId))
       ORDER BY s.startAt ASC, s.id ASC
     """)
     List<ScheduleEntity> findSchedulesByCalendarIdAndUser(

--- a/backend/src/main/java/com/chpark/chcalendar/service/notification/NotificationScheduleService.java
+++ b/backend/src/main/java/com/chpark/chcalendar/service/notification/NotificationScheduleService.java
@@ -56,7 +56,6 @@ public class NotificationScheduleService extends NotificationService {
 
         GroupUserEntity userInfo = groupUserService.getGroupUser(userId, groupId);
         notificationSchedule.getScheduleGroupDto().forEach(scheduleGroupDto -> {
-            groupUserService.checkGroupUserExists(groupId, scheduleGroupDto.getUserId());
 
             String message = userInfo.getGroupTitle() + messageFrom + scheduleGroupDto.getUserNickname() + "님을 초대합니다.";
             NotificationEntity entity = new NotificationEntity(

--- a/backend/src/main/java/com/chpark/chcalendar/service/schedule/ScheduleGroupService.java
+++ b/backend/src/main/java/com/chpark/chcalendar/service/schedule/ScheduleGroupService.java
@@ -76,7 +76,7 @@ public class ScheduleGroupService {
 
         Optional<ScheduleGroupEntity> targetUserInfo = scheduleGroupRepository.findByScheduleIdAndUserId(scheduleDto.getId(), userId);
 
-        if (targetUserInfo.isEmpty()) {
+        if (userId != scheduleDto.getUserId() && targetUserInfo.isEmpty()) {
             return createScheduleGroup(scheduleDto, new HashSet<>(requestNewGroupList));
         }
 

--- a/backend/src/main/java/com/chpark/chcalendar/service/schedule/ScheduleService.java
+++ b/backend/src/main/java/com/chpark/chcalendar/service/schedule/ScheduleService.java
@@ -268,11 +268,12 @@ public class ScheduleService {
             throw new CustomException("has repeat-id");
         }
 
+        //그룹와 캘린더에 속했는지 확인
         CalendarUtility.checkCalendarAuthority(userId, schedule.get().getUserId(), calendarId, schedule.get().getId(), groupUserService, userCalendarService, scheduleGroupService);
 
         try {
             scheduleNotificationRepository.deleteByScheduleId(scheduleId);
-            scheduleRepository.deleteByIdAndUserId(scheduleId, userId);
+            scheduleRepository.deleteById(scheduleId);
             scheduleGroupService.deleteScheduleNotification(scheduleId);
         } catch (EmptyResultDataAccessException e) {
             throw new EntityNotFoundException("Schedule not found with schedule-id: " + scheduleId);

--- a/backend/src/main/java/com/chpark/chcalendar/service/user/GroupUserService.java
+++ b/backend/src/main/java/com/chpark/chcalendar/service/user/GroupUserService.java
@@ -63,7 +63,7 @@ public class GroupUserService {
     }
 
     public void checkGroupUserExists(long userId, long groupId) {
-        if(groupUserRepository.findByUserIdAndGroupId(userId, groupId).isPresent()) {
+        if (groupUserRepository.findByUserIdAndGroupId(userId, groupId).isPresent()) {
             throw new IllegalArgumentException("The user is already registered.");
         }
     }


### PR DESCRIPTION
- 그룹 유저 캘린더 만들어도 상대한테 안보이는 버그 select의 조건문에서 ScheduleGroupEntity에서 유저가 없을 때의 경우 값이 제대로 불러와지지 않았음

- 그룹 캘린더의 일정이 삭제가 안되는 버그 만든 user만 삭제 가능에서, user id 검증을 그룹에 속했을 때는 처리 가능하도록으로 변경

- 그룹 일정 안 만들어지는 버그 그룹 아이디를 확인할 때 그룹에 속하면 생성하지 못하도록 처리되어있어서 다시 그룹에 속했을 때 생성 가능하도록 처리