### PR TITLE
feat: 알림창, 더보기창 크기 조절 및 홈페이지 버튼 리프레시로 변경

### DIFF
--- a/frontend/src/components/HeaderComponent.jsx
+++ b/frontend/src/components/HeaderComponent.jsx
@@ -53,9 +53,16 @@ const HeaderComponent = forwardRef(({ mode, onSidebarToggle, onCloseSidebarPopup
   // 외부 클릭 감지
   useEffect(() => {
     const handleClickOutside = (event) => {
+      // 알림 버튼과 더보기 버튼 클릭은 무시
+      if (event.target.closest(`.${styles.notificationBell}`) || 
+          event.target.closest(`.${styles.moreButton}`)) {
+        return;
+      }
+      // 알림 드롭다운 외부 클릭시 닫기
       if (showDropdown && dropdownRef.current && !dropdownRef.current.contains(event.target)) {
         setShowDropdown(false);
       }
+      // 더보기 메뉴 외부 클릭시 닫기
       if (showMoreMenu && moreMenuRef.current && !moreMenuRef.current.contains(event.target)) {
         setShowMoreMenu(false);
       }
@@ -71,31 +78,13 @@ const HeaderComponent = forwardRef(({ mode, onSidebarToggle, onCloseSidebarPopup
   }, [showDropdown, showMoreMenu]);
 
   const toggleDropdown = () => {
-    setShowDropdown((prev) => {
-      if (!prev) {
-        setShowMoreMenu(false);
-        if (onCloseSidebarPopups) {
-          setTimeout(() => {
-            onCloseSidebarPopups();
-          }, 0);
-        }
-      }
-      return !prev;
-    });
+    setShowMoreMenu(false);
+    setShowDropdown((prev) => !prev);
   };
 
   const toggleMoreMenu = () => {
-    setShowMoreMenu((prev) => {
-      if (!prev) {
-        setShowDropdown(false);
-        if (onCloseSidebarPopups) {
-          setTimeout(() => {
-            onCloseSidebarPopups();
-          }, 0);
-        }
-      }
-      return !prev;
-    });
+    setShowDropdown(false);
+    setShowMoreMenu((prev) => !prev);
   };
 
   const handleSidebarToggle = () => {
@@ -178,7 +167,12 @@ const HeaderComponent = forwardRef(({ mode, onSidebarToggle, onCloseSidebarPopup
   };
 
   const handleHome = () => {
-    navigate("/");
+    // 현재 경로가 홈페이지('/')인 경우 새로고침
+    if (location.pathname === '/') {
+      window.location.reload();
+    } else {
+      navigate('/');
+    }
   };
 
   const handleProfile = () => {

--- a/frontend/src/styles/Header.module.css
+++ b/frontend/src/styles/Header.module.css
@@ -286,9 +286,12 @@
     top: calc(60px + env(safe-area-inset-top));
     right: 10px;
     width: calc(100vw - 20px);
-    max-width: 350px;
-    max-height: calc(var(--vh, 1vh) * 100 - 80px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+    max-width: calc(100vw - 20px);
+    max-height: calc(100vh - 80px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
     overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    margin: 0;
+    box-sizing: border-box;
   }
 
   .notificationSelect {
@@ -296,6 +299,8 @@
     right: 10px;
     width: auto;
     max-width: calc(100vw - 20px);
+    max-height: calc(100vh - 80px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+    overflow-y: auto;
   }
 
   .moreMenu {


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #이슈번호, #이슈번호

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 알림 벨 및 더보기 버튼 클릭 시 드롭다운이 의도치 않게 닫히지 않도록 클릭 처리 로직이 개선되었습니다.
  - 홈 버튼을 현재 홈 경로에서 다시 클릭하면 페이지가 새로고침되도록 동작이 변경되었습니다.

- **스타일**
  - 모바일 환경에서 알림 드롭다운 및 선택 메뉴의 크기와 스크롤 동작이 개선되어, 화면에 맞게 더 자연스럽게 표시되고 iOS에서 부드럽게 스크롤됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->