### PR TITLE
fix: 소셜 계정 로그인이나 연동이 정상 작동하도록 수정

### DIFF
--- a/backend/src/main/java/com/chpark/chcalendar/controller/security/OAuth2Controller.java
+++ b/backend/src/main/java/com/chpark/chcalendar/controller/security/OAuth2Controller.java
@@ -3,6 +3,7 @@ package com.chpark.chcalendar.controller.security;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,17 +13,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class OAuth2Controller {
 
-    @PostMapping("/login")
-    public String login(HttpServletRequest request) {
+    @PostMapping("/login/{type}")
+    public String login(@PathVariable("type") String type,
+                        HttpServletRequest request) {
         HttpSession session = request.getSession();
-        session.setAttribute("oauth_login_type", "login");
+        session.setAttribute("oauth_login_type", type);
         return "/oauth2/authorization/google";
     }
 
-    @PostMapping("/link")
-    public String link(HttpServletRequest request) {
+    @PostMapping("/link/{userEmail}")
+    public String link(@PathVariable("userEmail") String userEmail,
+                       HttpServletRequest request) {
         HttpSession session = request.getSession();
         session.setAttribute("oauth_login_type", "link");
+        session.setAttribute("oauth_login_email", userEmail);
         return "/oauth2/authorization/google";
     }
 }

--- a/backend/src/main/java/com/chpark/chcalendar/entity/UserEntity.java
+++ b/backend/src/main/java/com/chpark/chcalendar/entity/UserEntity.java
@@ -43,8 +43,11 @@ public class UserEntity {
                 .nickname(request.getNickname())
                 .build();
 
-        UserProviderEntity provider = new UserProviderEntity();
-        provider.setProvider(request.getProvider());
+        UserProviderEntity provider = UserProviderEntity.builder()
+                .provider(request.getProvider())
+                .providerEmail(request.getEmail())
+                .user(user)
+                .build();
 
         user.addProvider(provider);
         return user;

--- a/backend/src/main/java/com/chpark/chcalendar/entity/UserProviderEntity.java
+++ b/backend/src/main/java/com/chpark/chcalendar/entity/UserProviderEntity.java
@@ -17,23 +17,28 @@ public class UserProviderEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 10)
-    private String provider = "local";
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private UserEntity user;
 
-    public UserProviderEntity(String provider, UserEntity user) {
+    @Column(nullable = false, length = 10)
+    private String provider = "local";
+
+    @Column(name = "provider_email")
+    private String providerEmail;
+
+    public UserProviderEntity(String provider, UserEntity user, String providerEmail) {
         this.provider = provider;
         this.user = user;
+        this.providerEmail = providerEmail;
     }
 
     @Builder
-    public UserProviderEntity(Long id, String provider, UserEntity user) {
+    public UserProviderEntity(Long id, String provider, UserEntity user, String providerEmail) {
         this.id = id;
         this.provider = provider;
         this.user = user;
+        this.providerEmail = providerEmail;
     }
 }
 

--- a/backend/src/main/java/com/chpark/chcalendar/repository/user/UserProviderRepository.java
+++ b/backend/src/main/java/com/chpark/chcalendar/repository/user/UserProviderRepository.java
@@ -12,4 +12,5 @@ public interface UserProviderRepository extends JpaRepository<UserProviderEntity
     void deleteByUserId(long userId);
 
     List<UserProviderEntity> findByUserId(long userId);
+    List<UserProviderEntity> findByProviderEmail(String providerEmail);
 }

--- a/backend/src/main/java/com/chpark/chcalendar/utility/ScheduleUtility.java
+++ b/backend/src/main/java/com/chpark/chcalendar/utility/ScheduleUtility.java
@@ -85,6 +85,7 @@ public class ScheduleUtility {
         }
     }
 
+    //TODO: 다른 유틸리티 관심사로 이동 필요
     public static void validateEmail(String email) {
         EmailValidator validator = EmailValidator.getInstance();
         if (!validator.isValid(email)) {

--- a/frontend/src/components/pages/LoginPage.jsx
+++ b/frontend/src/components/pages/LoginPage.jsx
@@ -71,7 +71,7 @@ const LoginPage = () => {
       );
 
       if (isGoogleLinked) {
-        const response = await axios.post("/auth/oauth2/login", { type: "local"}, {
+        const response = await axios.post(`/auth/oauth2/login/${"local"}`, {
           withCredentials: true
         });
 
@@ -132,7 +132,7 @@ const LoginPage = () => {
         onClick={async () => {
           setLoading(true);
           try {
-            const response = await axios.post("/auth/oauth2/login", { type: "oauth" }, {
+            const response = await axios.post(`/auth/oauth2/login/${"oauth"}`, {
               withCredentials: true
             });
             window.location.href = `${process.env.REACT_APP_DOMAIN}${response.data}`;

--- a/frontend/src/components/pages/ProfilePage.jsx
+++ b/frontend/src/components/pages/ProfilePage.jsx
@@ -4,6 +4,7 @@ import styles from "styles/Profile.module.css";
 import Button from "../Button";
 import HeaderComponent from "../HeaderComponent";
 import popupStyles from "styles/Popup.module.css";
+import LoadingOverlay from "../LoadingOverlay";
 
 const ProfilePage = () => {
   const [email, setEmail] = useState("");
@@ -14,6 +15,7 @@ const ProfilePage = () => {
   const [isNicknameChanged, setIsNicknameChanged] = useState(false);
   const [providers, setProviders] = useState([]);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     fetchUserInfo();
@@ -107,12 +109,11 @@ const ProfilePage = () => {
 
   const handleGoogleLink = async () => {
     try {
-      const response = await axios.post("/auth/oauth2/link", null, {
+      const response = await axios.post(`/auth/oauth2/link/${email}`, null, {
         withCredentials: true
       });
-      
-      // 응답으로 받은 URL로 리다이렉트
-      window.location.href = `${process.env.REACT_APP_DOMAIN}${response.data}`;
+      // eslint-disable-next-line
+      window.location.href = process.env.REACT_APP_DOMAIN + response.data;
     } catch (error) {
       console.error("Failed to initiate Google account linking:", error);
       alert("Google 계정 연동을 시작할 수 없습니다. 다시 시도해주세요.");
@@ -126,6 +127,7 @@ const ProfilePage = () => {
   // 회원탈퇴 핸들러 추가
   const handleDeleteAccount = async () => {
     setShowDeleteModal(false);
+    setIsLoading(true);
     try {
       await axios.delete("/user", { withCredentials: true });
       alert("회원 탈퇴가 완료되었습니다.");
@@ -133,11 +135,14 @@ const ProfilePage = () => {
       window.location.href = "/";
     } catch (error) {
       alert(error?.response?.data?.message || "회원 탈퇴에 실패했습니다.");
+    } finally {
+      setIsLoading(false);
     }
   };
 
   return (
     <div>
+      {isLoading && <LoadingOverlay fullScreen={true} />}
       <HeaderComponent mode="profile" />
 
       <div className={styles.formContainer}>


### PR DESCRIPTION
## #️⃣연관된 이슈
> #118

## 📝작업 내용
- 기존 유저의 이메일과 소셜 계정의 이메일이 다른 상태에서 연동시 연동이 되지 않는 문제 수정
- 회원 탈퇴시 로딩 표시
- 소셜 연동, 소셜 회원 가입시에 이메일 체크 추가

